### PR TITLE
Handle circular structures

### DIFF
--- a/lib/canopi.js
+++ b/lib/canopi.js
@@ -1,5 +1,6 @@
 const individual = require('individual')
 const levels = ['debug', 'info', 'warn', 'error']
+const stringify = require('fast-safe-stringify')
 
 const canopiConfig = individual('__CANOPI_CONFIG', {
   outputStream: process.stdout,
@@ -129,7 +130,7 @@ function canopi (a1, a2) {
         return canopiLogger[level](e)
       }
 
-      canopiConfig.outputStream.write(JSON.stringify(loggable) + '\n')
+      canopiConfig.outputStream.write(stringify(loggable) + '\n')
     }
   }
 

--- a/lib/canopi.test.js
+++ b/lib/canopi.test.js
@@ -203,3 +203,13 @@ test('unsupported uses', (t) => {
   b.reset()
 })
 
+test('circular structures', (t) => {
+  t.plan(1)
+  const log = canopi()
+  const b = bufferingWritable()
+  canopi.setOutputStream(b)
+  const circ1 = {}
+  const circ2 = { circ1 }
+  circ1.circ2 = { circ2 }
+  t.doesNotThrow(() => log.info(circ1))
+})

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "tape-catch": "^1.0.6"
   },
   "dependencies": {
+    "fast-safe-stringify": "^1.1.6",
     "individual": "^3.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,6 +518,10 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fast-safe-stringify@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-1.1.6.tgz#b30f4a55cbf657895a5b07b2c9c6fec91580802d"
+
 figures@^1.3.5, figures@^1.4.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"


### PR DESCRIPTION
canopi currently will throw if you try to log a circular data structure. There are often cases where circular data structures are used in node, the most common being http `request`/`response` pairs which reference each other.

I added a (failing) test for this, and added `fast-safe-stringify` to do the object serialisation (à la  bole) which works nicely.